### PR TITLE
README: fix install example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ testing.
 
 The simplest way of installing this plugin is by running the follow go command.
 
-`go install github.com/Foxboron/ssh-tpm-agent/cmd/...@latest`
+`go install github.com/foxboron/ssh-tpm-agent/cmd/...@latest`
 
 Alternatively download the [pre-built binaries](https://github.com/foxboron/ssh-tpm-plugin/releases).
 


### PR DESCRIPTION
```
$ go install github.com/Foxboron/ssh-tpm-agent/cmd/...@latest                           
go: github.com/Foxboron/ssh-tpm-agent/cmd/...@latest: github.com/Foxboron/ssh-tpm-agent@v0.1.0: parsing go.mod:
	module declares its path as: github.com/foxboron/ssh-tpm-agent
	        but was required as: github.com/Foxboron/ssh-tpm-agent

```