### PR TITLE
agent: Allow password-caching in pinentry

### DIFF
--- a/cmd/ssh-tpm-agent/main.go
+++ b/cmd/ssh-tpm-agent/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/sha256"
 	"flag"
 	"fmt"
 	"log"
@@ -84,8 +85,10 @@ func main() {
 		}
 		return tpm
 	}
-	pin := func(_ *key.Key) ([]byte, error) {
-		return pinentry.GetPinentry()
+	pin := func(key *key.Key) ([]byte, error) {
+		keyHash := sha256.Sum256(key.Public.Bytes())
+		keyInfo := fmt.Sprintf("ssh-tpm-agent/%x", keyHash)
+		return pinentry.GetPinentry(keyInfo)
 	}
 	agent.RunAgent(socketPath, tpmFetch, pin)
 }

--- a/pinentry/pinentry.go
+++ b/pinentry/pinentry.go
@@ -10,9 +10,11 @@ var (
 	ErrPinentryCancelled = errors.New("cancelled pinentry")
 )
 
-func GetPinentry() ([]byte, error) {
+func GetPinentry(keyInfo string) ([]byte, error) {
 	// TODO: Include some additional key metadata
 	client, err := pinentry.NewClient(
+		pinentry.WithCommand("OPTION allow-external-password-cache"),
+		pinentry.WithCommandf("SETKEYINFO %v", keyInfo),
 		pinentry.WithBinaryNameFromGnuPGAgentConf(),
 		pinentry.WithDesc("Enter PIN for TPM key"),
 		pinentry.WithGPGTTY(),


### PR DESCRIPTION
Note: This PR might need some more work

This allows pinentry-gtk2 (and maybe other pinentries) to cache PIN using libsecret/gnome-keychain

- Sets `OPTION allow-external-password-cache`
- Set `SETINFO` to `"ssh-tpm-agent/" + sha256(publicKey)` (this should prob be something else)

One problem is that cached passwords names are prefixed with "GnuPG: ", not yet figured out how to fix that.