### PR TITLE
ssh-tpm-agent: Add ssh-agent proxy functionality with -A

### DIFF
--- a/cmd/ssh-tpm-agent/main_test.go
+++ b/cmd/ssh-tpm-agent/main_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/go-tpm/tpm2/transport"
 	"github.com/google/go-tpm/tpm2/transport/simulator"
 	"golang.org/x/crypto/ssh"
+	sshagent "golang.org/x/crypto/ssh/agent"
 )
 
 func newSSHKey() ssh.Signer {
@@ -127,6 +128,7 @@ func TestSSHAuth(t *testing.T) {
 	socket := path.Join(t.TempDir(), "socket")
 
 	ag := agent.NewAgent(socket,
+		[]sshagent.ExtendedAgent{},
 		// TPM Callback
 		func() transport.TPMCloser {
 			return tpm

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,6 @@ require (
 	github.com/rs/zerolog v1.26.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
+	golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b // indirect
 	golang.org/x/sys v0.10.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.11.0 h1:6Ewdq3tDic1mg5xRO4milcWCfMVQhI4NkqWWvqejpuA=
 golang.org/x/crypto v0.11.0/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIio=
+golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b h1:r+vk0EmXNmekl0S0BascoeeoHk/L7wmaW2QF90K+kYI=
+golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=


### PR DESCRIPTION
Allows `ssh-tpm-agent` act as a proxy between multiple ssh-agent
compatible agents.

It will deliver all available signers, from itself and all proxies, to
the ssh server, and then pass the signing requests to all the agents.

Fixes: https://github.com/Foxboron/ssh-tpm-agent/issues/9

Signed-off-by: Morten Linderud <morten@linderud.pw>