### PR TITLE
Implement import of existing keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/foxboron/swtpm_test v0.0.0-20230726224112-46aaafdf7006
-	github.com/google/go-tpm v0.9.1-0.20230720145701-e9722e4450de
+	github.com/google/go-tpm v0.9.1-0.20230807150904-c49efc441a60
 	github.com/twpayne/go-pinentry v0.2.0
 	golang.org/x/crypto v0.11.0
 	golang.org/x/term v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/foxboron/swtpm_test v0.0.0-20230726224112-46aaafdf7006/go.mod h1:eIXC
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/google/go-sev-guest v0.6.1 h1:NajHkAaLqN9/aW7bCFSUplUMtDgk2+HcN7jC2btFtk0=
-github.com/google/go-tpm v0.9.1-0.20230720145701-e9722e4450de h1:dbrX2X/8QXV6Qp4FBo8c9Tmch9/v6vex90YdiZu5bGQ=
-github.com/google/go-tpm v0.9.1-0.20230720145701-e9722e4450de/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
+github.com/google/go-tpm v0.9.1-0.20230807150904-c49efc441a60 h1:WZpppXXHrrk6r76Vn2HPf1S/5MhuVjiaef3FHeLf0vA=
+github.com/google/go-tpm v0.9.1-0.20230807150904-c49efc441a60/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
 github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba h1:qJEJcuLzH5KDR0gKc0zcktin6KSAwL7+jWKBYceddTc=
 github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba/go.mod h1:EFYHy8/1y2KfgTAsx7Luu7NGhoxtuVHnNo8jE7FikKc=
 github.com/google/logger v1.1.1 h1:+6Z2geNxc9G+4D4oDO9njjjn2d0wN5d7uOo0vOIW1NQ=

--- a/key/key.go
+++ b/key/key.go
@@ -328,22 +328,117 @@ func CreateKey(tpm transport.TPMCloser, keytype tpm2.TPMAlgID, pin []byte) (*Key
 	}, nil
 }
 
-func ImportKey(tpm transport.TPMCloser, pk ecdsa.PrivateKey, pin []byte) (*Key, error) {
-	srkHandle, srkPublic, err := CreateSRK(tpm, tpm2.TPMAlgECDSA)
+func ImportKey(tpm transport.TPMCloser, pk any, pin []byte) (*Key, error) {
+
+	var public tpm2.TPMTPublic
+	var sensitive tpm2.TPMTSensitive
+	var unique tpm2.TPMUPublicID
+
+	var keytype tpm2.TPMAlgID
+
+	switch p := pk.(type) {
+	case ecdsa.PrivateKey:
+
+		keytype = tpm2.TPMAlgECDSA
+
+		// Prepare ECDSA key for importing
+		sensitive = tpm2.TPMTSensitive{
+			SensitiveType: tpm2.TPMAlgECC,
+			Sensitive: tpm2.NewTPMUSensitiveComposite(
+				tpm2.TPMAlgECC,
+				&tpm2.TPM2BECCParameter{Buffer: p.D.FillBytes(make([]byte, 32))},
+			),
+		}
+
+		unique = tpm2.NewTPMUPublicID(
+			tpm2.TPMAlgECC,
+			&tpm2.TPMSECCPoint{
+				X: tpm2.TPM2BECCParameter{
+					Buffer: p.X.FillBytes(make([]byte, 32)),
+				},
+				Y: tpm2.TPM2BECCParameter{
+					Buffer: p.Y.FillBytes(make([]byte, 32)),
+				},
+			},
+		)
+
+		public = tpm2.TPMTPublic{
+			Type:    tpm2.TPMAlgECC,
+			NameAlg: tpm2.TPMAlgSHA256,
+			ObjectAttributes: tpm2.TPMAObject{
+				SignEncrypt:  true,
+				UserWithAuth: true,
+			},
+			Parameters: tpm2.NewTPMUPublicParms(
+				tpm2.TPMAlgECC,
+				&tpm2.TPMSECCParms{
+					CurveID: tpm2.TPMECCNistP256,
+					Scheme: tpm2.TPMTECCScheme{
+						Scheme: tpm2.TPMAlgECDSA,
+						Details: tpm2.NewTPMUAsymScheme(
+							tpm2.TPMAlgECDSA,
+							&tpm2.TPMSSigSchemeECDSA{
+								HashAlg: tpm2.TPMAlgSHA256,
+							},
+						),
+					},
+				},
+			),
+			Unique: unique,
+		}
+
+	case rsa.PrivateKey:
+		keytype = tpm2.TPMAlgRSA
+
+		// Prepare RSA key for importing
+		sensitive = tpm2.TPMTSensitive{
+			SensitiveType: tpm2.TPMAlgRSA,
+			Sensitive: tpm2.NewTPMUSensitiveComposite(
+				tpm2.TPMAlgRSA,
+				&tpm2.TPM2BPrivateKeyRSA{Buffer: p.Primes[0].Bytes()},
+			),
+		}
+
+		unique = tpm2.NewTPMUPublicID(
+			tpm2.TPMAlgRSA,
+			&tpm2.TPM2BPublicKeyRSA{Buffer: p.N.Bytes()},
+		)
+
+		public = tpm2.TPMTPublic{
+			Type:    tpm2.TPMAlgRSA,
+			NameAlg: tpm2.TPMAlgSHA256,
+			ObjectAttributes: tpm2.TPMAObject{
+				SignEncrypt:  true,
+				UserWithAuth: true,
+			},
+			Parameters: tpm2.NewTPMUPublicParms(
+				tpm2.TPMAlgRSA,
+				&tpm2.TPMSRSAParms{
+					Scheme: tpm2.TPMTRSAScheme{
+						Scheme: tpm2.TPMAlgRSASSA,
+						Details: tpm2.NewTPMUAsymScheme(
+							tpm2.TPMAlgRSASSA,
+							&tpm2.TPMSSigSchemeRSASSA{
+								HashAlg: tpm2.TPMAlgSHA256,
+							},
+						),
+					},
+					KeyBits: 2048,
+				},
+			),
+			Unique: unique,
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported key type")
+	}
+
+	srkHandle, srkPublic, err := CreateSRK(tpm, keytype)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating SRK: %v", err)
 	}
 
 	defer utils.FlushHandle(tpm, srkHandle)
-
-	// Prepare ECDSA key for importing
-	sensitive := tpm2.TPMTSensitive{
-		SensitiveType: tpm2.TPMAlgECC,
-		Sensitive: tpm2.NewTPMUSensitiveComposite(
-			tpm2.TPMAlgECC,
-			&tpm2.TPM2BECCParameter{Buffer: pk.D.FillBytes(make([]byte, 32))},
-		),
-	}
 
 	pinstatus := NoPIN
 
@@ -357,49 +452,14 @@ func ImportKey(tpm transport.TPMCloser, pk ecdsa.PrivateKey, pin []byte) (*Key, 
 	// We need the size calcualted in the buffer, so we do this serialization dance
 	l := tpm2.Marshal(tpm2.TPM2BPrivate{Buffer: tpm2.Marshal(sensitive)})
 
-	eccPublicImport := tpm2.New2B(tpm2.TPMTPublic{
-		Type:    tpm2.TPMAlgECC,
-		NameAlg: tpm2.TPMAlgSHA256,
-		ObjectAttributes: tpm2.TPMAObject{
-			SignEncrypt:  true,
-			UserWithAuth: true,
-		},
-		Parameters: tpm2.NewTPMUPublicParms(
-			tpm2.TPMAlgECC,
-			&tpm2.TPMSECCParms{
-				CurveID: tpm2.TPMECCNistP256,
-				Scheme: tpm2.TPMTECCScheme{
-					Scheme: tpm2.TPMAlgECDSA,
-					Details: tpm2.NewTPMUAsymScheme(
-						tpm2.TPMAlgECDSA,
-						&tpm2.TPMSSigSchemeECDSA{
-							HashAlg: tpm2.TPMAlgSHA256,
-						},
-					),
-				},
-			},
-		),
-		Unique: tpm2.NewTPMUPublicID(
-			tpm2.TPMAlgECC,
-			&tpm2.TPMSECCPoint{
-				X: tpm2.TPM2BECCParameter{
-					Buffer: pk.X.FillBytes(make([]byte, 32)),
-				},
-				Y: tpm2.TPM2BECCParameter{
-					Buffer: pk.Y.FillBytes(make([]byte, 32)),
-				},
-			},
-		),
-	})
-
-	eccImport := tpm2.Import{
+	importCmd := tpm2.Import{
 		ParentHandle: srkHandle,
 		Duplicate:    tpm2.TPM2BPrivate{Buffer: l},
-		ObjectPublic: eccPublicImport,
+		ObjectPublic: tpm2.New2B(public),
 	}
 
 	var importRsp *tpm2.ImportResponse
-	importRsp, err = eccImport.Execute(tpm,
+	importRsp, err = importCmd.Execute(tpm,
 		tpm2.HMAC(tpm2.TPMAlgSHA256, 16,
 			tpm2.AESEncryption(128, tpm2.EncryptIn),
 			tpm2.Salted(srkHandle.Handle, *srkPublic)))
@@ -411,8 +471,8 @@ func ImportKey(tpm transport.TPMCloser, pk ecdsa.PrivateKey, pin []byte) (*Key, 
 		Version: 1,
 		PIN:     pinstatus,
 		Private: importRsp.OutPrivate,
-		Public:  eccPublicImport,
-		Type:    tpm2.TPMAlgECDSA,
+		Public:  importCmd.ObjectPublic,
+		Type:    keytype,
 	}, nil
 }
 

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -3,6 +3,8 @@ package signer
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"fmt"
@@ -140,6 +142,151 @@ func TestSigning(t *testing.T) {
 					t.Errorf("Signature verification failed: %v", err)
 				}
 			}
+		})
+	}
+}
+
+func TestSigningWithImportedKey(t *testing.T) {
+	cases := []struct {
+		msg        string
+		keytype    tpm2.TPMAlgID
+		filekey    []byte
+		pin        []byte
+		signpin    []byte
+		shouldfail bool
+	}{
+		{
+			msg:     "ecdsa encryption/decrypt - no pin",
+			keytype: tpm2.TPMAlgECDSA,
+			filekey: []byte("this is a test filekey"),
+		},
+		{
+			msg:     "ecdsa encryption/decrypt - pin",
+			keytype: tpm2.TPMAlgECDSA,
+			filekey: []byte("this is a test filekey"),
+			pin:     []byte("123"),
+			signpin: []byte("123"),
+		},
+		{
+			msg:        "ecdsa encryption/decrypt - no pin for sign",
+			keytype:    tpm2.TPMAlgECDSA,
+			filekey:    []byte("this is a test filekey"),
+			pin:        []byte("123"),
+			shouldfail: true,
+		},
+		{
+			msg:     "rsa encryption/decrypt - no pin for key, pin for sign",
+			keytype: tpm2.TPMAlgRSA,
+			filekey: []byte("this is a test filekey"),
+			pin:     []byte(""),
+			signpin: []byte("123"),
+		},
+		{
+			msg:     "rsa encryption/decrypt - no pin",
+			keytype: tpm2.TPMAlgRSA,
+			filekey: []byte("this is a test filekey"),
+		},
+		{
+			msg:     "rsa encryption/decrypt - pin",
+			keytype: tpm2.TPMAlgRSA,
+			filekey: []byte("this is a test filekey"),
+			pin:     []byte("123"),
+			signpin: []byte("123"),
+		},
+		{
+			msg:        "rsa encryption/decrypt - no pin for sign",
+			keytype:    tpm2.TPMAlgRSA,
+			filekey:    []byte("this is a test filekey"),
+			pin:        []byte("123"),
+			shouldfail: true,
+		},
+		{
+			msg:     "rsa encryption/decrypt - no pin for key, pin for sign",
+			keytype: tpm2.TPMAlgRSA,
+			filekey: []byte("this is a test filekey"),
+			pin:     []byte(""),
+			signpin: []byte("123"),
+		},
+	}
+
+	for n, c := range cases {
+		t.Run(fmt.Sprintf("case %d, %s", n, c.msg), func(t *testing.T) {
+			// Always re-init simulator as the Signer is going to close it,
+			// and we can't retain state.
+			tpm, err := simulator.OpenSimulator()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tpm.Close()
+
+			b := sha256.Sum256([]byte("heyho"))
+
+			var pk any
+			if c.keytype == tpm2.TPMAlgECDSA {
+				p, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				if err != nil {
+					t.Fatalf("failed to generate ecdsa key: %v", err)
+				}
+				pk = *p
+			} else if c.keytype == tpm2.TPMAlgRSA {
+				p, err := rsa.GenerateKey(rand.Reader, 2048)
+				if err != nil {
+					t.Fatalf("failed to generate ecdsa key: %v", err)
+				}
+				pk = *p
+			}
+
+			k, err := key.ImportKey(tpm, pk, c.pin)
+			if err != nil {
+				t.Fatalf("failed key import: %v", err)
+			}
+
+			signer := NewTPMSigner(k,
+				func() transport.TPMCloser { return tpm },
+				func(_ *key.Key) ([]byte, error) { return c.signpin, nil },
+			)
+
+			// Empty reader, we don't use this
+			var r io.Reader
+
+			sig, err := signer.Sign(r, b[:], crypto.SHA256)
+			if err != nil {
+				if c.shouldfail {
+					return
+				}
+				t.Fatalf("%v", err)
+			}
+
+			pubkey, err := k.PublicKey()
+			if err != nil {
+				if c.shouldfail {
+					return
+				}
+				t.Fatalf("failed getting pubkey: %v", err)
+			}
+
+			if err != nil {
+				if c.shouldfail {
+					return
+				}
+				t.Fatalf("failed test: %v", err)
+			}
+
+			if c.shouldfail {
+				t.Fatalf("test should be failing")
+			}
+
+			switch pk := pubkey.(type) {
+			case *ecdsa.PublicKey:
+				if !ecdsa.VerifyASN1(pk, b[:], sig) {
+					t.Fatalf("invalid signature")
+				}
+			case *rsa.PublicKey:
+				if err := rsa.VerifyPKCS1v15(pk, crypto.SHA256, b[:], sig); err != nil {
+					t.Errorf("Signature verification failed: %v", err)
+				}
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
```sh
λ ssh-tpm-agent master Ɇ » ssh-keygen -t ecdsa
Generating public/private ecdsa key pair.
Enter file in which to save the key (/home/fox/.ssh/id_ecdsa): ./test-key
Enter passphrase (empty for no passphrase):
Enter same passphrase again:
Your identification has been saved in ./test-key
Your public key has been saved in ./test-key.pub
The key fingerprint is:
SHA256:ZAR5B+p10hjevO9gD1X6bwOnmlPIRwLYJbvklDzop44 fox@framework
The key's randomart image is:
+---[ECDSA 256]---+
|      .o*o..     |
|      .=+O=      |
|      .oBO*   .  |
|     ..++ooo +   |
|      ..S+o *    |
|        o  = = . |
|       .  + + =  |
|      o  . *.. o.|
|     E .   o=  .o|
+----[SHA256]-----+

λ ssh-tpm-agent master Ɇ » ./ssh-tpm-keygen --import ./test-key
Sealing an existing public/private ecdsa key pair.
Enter existing password (empty for no pin):
./test-key.tpm already exists.
Overwrite (y/n)?y
Enter pin (empty for no pin):
Confirm pin:
Your identification has been saved in ./test-key.tpm
The key fingerprint is:
SHA256:ZAR5B+p10hjevO9gD1X6bwOnmlPIRwLYJbvklDzop44
The key's randomart image is the color of television, tuned to a dead channel.
```

Depends on https://github.com/google/go-tpm/pull/341