### PR TITLE
Fix .tpm suffix in ssh-tmp-keygen

### DIFF
--- a/cmd/ssh-tpm-keygen/main.go
+++ b/cmd/ssh-tpm-keygen/main.go
@@ -262,7 +262,7 @@ func main() {
 			log.Fatal(err)
 		}
 		if filenameInput != "" {
-			filename = filenameInput
+			filename = strings.TrimSuffix(filenameInput, ".tpm")
 		}
 
 	}


### PR DESCRIPTION
Resolves https://github.com/Foxboron/ssh-tpm-agent/issues/25

Tested in my local

```
Generating a sealed public/private ecdsa key pair.
Enter file in which to save the key (/root/.ssh/id_ecdsa): /root/.ssh/id_ecdsa_demo2.tpm
Enter pin (empty for no pin): 
Confirm pin: 
Your identification has been saved in /root/.ssh/id_ecdsa_demo2.tpm
```