### PR TITLE
add support for persistent srk

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -30,6 +30,7 @@ func TestAddKey(t *testing.T) {
 
 	ag := NewAgent(unixList,
 		[]agent.ExtendedAgent{},
+		0x0,
 		// TPM Callback
 		func() transport.TPMCloser { return tpm },
 		// Owner password
@@ -47,7 +48,7 @@ func TestAddKey(t *testing.T) {
 
 	client := agent.NewClient(conn)
 
-	k, err := key.CreateKey(tpm, tpm2.TPMAlgECC, 256, []byte(""), []byte(""), "")
+	k, err := key.CreateKey(tpm, tpm2.TPMAlgECC, 256, []byte(""), 0x0, []byte(""), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/ssh-tpm-agent/main_test.go
+++ b/cmd/ssh-tpm-agent/main_test.go
@@ -139,6 +139,7 @@ func runSSHAuth(t *testing.T, keytype tpm2.TPMAlgID, bits int, pin []byte, keyfn
 
 	ag := agent.NewAgent(unixList,
 		[]sshagent.ExtendedAgent{},
+		0x0,
 		// TPM Callback
 		func() transport.TPMCloser { return tpm },
 		// Owner password

--- a/internal/keytest/keytest.go
+++ b/internal/keytest/keytest.go
@@ -36,7 +36,7 @@ func MkECDSA(t *testing.T, a elliptic.Curve) ecdsa.PrivateKey {
 // Test helper for CreateKey
 func MkKey(t *testing.T, tpm transport.TPMCloser, keytype tpm2.TPMAlgID, bits int, pin []byte, comment string) (*key.Key, error) {
 	t.Helper()
-	return key.CreateKey(tpm, keytype, bits, []byte(""), pin, comment)
+	return key.CreateKey(tpm, keytype, bits, []byte(""), 0x0, pin, comment)
 }
 
 // Helper to make an importable key
@@ -56,7 +56,7 @@ func MkImportableKey(t *testing.T, tpm transport.TPMCloser, keytype tpm2.TPMAlgI
 	case tpm2.TPMAlgRSA:
 		pk = MkRSA(t, bits)
 	}
-	return key.ImportKey(tpm, []byte(""), pk, pin, comment)
+	return key.ImportKey(tpm, []byte(""), 0x0, pk, pin, comment)
 }
 
 // Give us some random bytes

--- a/key/key_test.go
+++ b/key/key_test.go
@@ -52,14 +52,14 @@ func TestCreateKey(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.text, func(t *testing.T) {
-			k, err := CreateKey(tpm, c.alg, c.bits, []byte(""), []byte(""), "")
+			k, err := CreateKey(tpm, c.alg, c.bits, []byte(""), 0x0, []byte(""), "")
 			if err != nil {
 				t.Fatalf("failed key import: %v", err)
 			}
 
 			// Test if we can load the key
 			// signer/signer_test.go tests the signing of the key
-			handle, err := LoadKey(tpm, []byte(""), k)
+			handle, err := LoadKey(tpm, []byte(""), 0x0, k)
 			if err != nil {
 				t.Fatalf("failed loading key: %v", err)
 			}
@@ -117,14 +117,14 @@ func TestCreateKeyWithOwnerPassword(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.text, func(t *testing.T) {
-			k, err := CreateKey(tpm, c.alg, c.bits, ownerPassword, []byte(""), "")
+			k, err := CreateKey(tpm, c.alg, c.bits, ownerPassword, 0x0, []byte(""), "")
 			if err != nil {
 				t.Errorf("failed key import: %v", err)
 			}
 
 			// Test if we can load the key
 			// signer/signer_test.go tests the signing of the key
-			handle, err := LoadKey(tpm, ownerPassword, k)
+			handle, err := LoadKey(tpm, ownerPassword, 0x0, k)
 			if err != nil {
 				t.Errorf("failed loading key: %v", err)
 			}
@@ -165,7 +165,7 @@ func TestImport(t *testing.T) {
 		},
 	} {
 		t.Run(c.text, func(t *testing.T) {
-			k, err := ImportKey(tpm, []byte(""), c.pk, []byte(""), "")
+			k, err := ImportKey(tpm, []byte(""), 0x0, c.pk, []byte(""), "")
 			if err != nil && c.fail {
 				return
 			}
@@ -175,7 +175,7 @@ func TestImport(t *testing.T) {
 
 			// Test if we can load the key
 			// signer/signer_test.go tests the signing of the key
-			handle, err := LoadKey(tpm, []byte(""), k)
+			handle, err := LoadKey(tpm, []byte(""), 0x0, k)
 			if err != nil {
 				t.Fatalf("failed loading key: %v", err)
 			}
@@ -221,7 +221,7 @@ func TestKeyPublickey(t *testing.T) {
 		},
 	} {
 		t.Run(c.text, func(t *testing.T) {
-			k, err := ImportKey(tpm, []byte(""), c.pk, []byte(""), "")
+			k, err := ImportKey(tpm, []byte(""), 0x0, c.pk, []byte(""), "")
 			if err != nil && c.fail {
 				return
 			}
@@ -336,22 +336,22 @@ func TestChangeAuth(t *testing.T) {
 			h.Write([]byte(c.text))
 			b := h.Sum(nil)
 
-			_, err = Sign(tpm, []byte(""), k, b, c.oldPin, tpm2.TPMAlgSHA256)
+			_, err = Sign(tpm, []byte(""), 0x0, k, b, c.oldPin, tpm2.TPMAlgSHA256)
 			if err != nil {
 				t.Fatalf("signing with correct pin should not fail: %v", err)
 			}
 
-			key, err := ChangeAuth(tpm, []byte(""), k, c.oldPin, c.newPin)
+			key, err := ChangeAuth(tpm, []byte(""), 0x0, k, c.oldPin, c.newPin)
 			if err != nil {
 				t.Fatalf("ChangeAuth shouldn't fail: %v", err)
 			}
 
-			_, err = Sign(tpm, []byte(""), key, b, c.oldPin, tpm2.TPMAlgSHA256)
+			_, err = Sign(tpm, []byte(""), 0x0, key, b, c.oldPin, tpm2.TPMAlgSHA256)
 			if errors.Is(err, tpm2.TPMRCBadAuth) {
 				t.Fatalf("old pin works on updated key")
 			}
 
-			_, err = Sign(tpm, []byte(""), key, b, c.newPin, tpm2.TPMAlgSHA256)
+			_, err = Sign(tpm, []byte(""), 0x0, key, b, c.newPin, tpm2.TPMAlgSHA256)
 			if errors.Is(err, tpm2.TPMRCBadAuth) {
 				t.Fatalf("new pin doesn't work")
 			}

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -13,16 +13,18 @@ import (
 type TPMSigner struct {
 	key           *key.Key
 	ownerPassword func() ([]byte, error)
+	srkHandle     tpm2.TPMHandle
 	tpm           func() transport.TPMCloser
 	pin           func(*key.Key) ([]byte, error)
 }
 
 var _ crypto.Signer = &TPMSigner{}
 
-func NewTPMSigner(k *key.Key, ownerPassword func() ([]byte, error), tpm func() transport.TPMCloser, pin func(*key.Key) ([]byte, error)) *TPMSigner {
+func NewTPMSigner(k *key.Key, ownerPassword func() ([]byte, error), srkHandle tpm2.TPMHandle, tpm func() transport.TPMCloser, pin func(*key.Key) ([]byte, error)) *TPMSigner {
 	return &TPMSigner{
 		key:           k,
 		ownerPassword: ownerPassword,
+		srkHandle:     srkHandle,
 		tpm:           tpm,
 		pin:           pin,
 	}
@@ -65,5 +67,5 @@ func (t *TPMSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]
 		return nil, err
 	}
 
-	return key.Sign(t.tpm(), ownerPassword, t.key, digest, auth, digestalg)
+	return key.Sign(t.tpm(), ownerPassword, t.srkHandle, t.key, digest, auth, digestalg)
 }

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -112,13 +112,14 @@ func TestSigning(t *testing.T) {
 			h.Write([]byte("heyho"))
 			b := h.Sum(nil)
 
-			k, err := key.CreateKey(tpm, c.keytype, c.bits, []byte(""), c.pin, "")
+			k, err := key.CreateKey(tpm, c.keytype, c.bits, []byte(""), 0x0, c.pin, "")
 			if err != nil {
 				t.Fatalf("%v", err)
 			}
 
 			signer := NewTPMSigner(k,
 				func() ([]byte, error) { return []byte(""), nil },
+				0x0,
 				func() transport.TPMCloser { return tpm },
 				func(_ *key.Key) ([]byte, error) { return c.signpin, nil },
 			)
@@ -171,42 +172,42 @@ func TestSigningWithOwnerPassword(t *testing.T) {
 	ownerPassword := []byte("testPassword")
 
 	cases := []struct {
-		msg        		string
-		keytype    		tpm2.TPMAlgID
-		bits       		int
-		digest     		crypto.Hash
-		filekey    		[]byte
-		pin        		[]byte
-		signpin    		[]byte
-		ownerpassword 	[]byte
- 		shouldfail 		bool
+		msg           string
+		keytype       tpm2.TPMAlgID
+		bits          int
+		digest        crypto.Hash
+		filekey       []byte
+		pin           []byte
+		signpin       []byte
+		ownerpassword []byte
+		shouldfail    bool
 	}{
 		{
-			msg:     		"ecdsa - test encryption/decrypt - no pin",
-			filekey: 		[]byte("this is a test filekey"),
-			keytype: 		tpm2.TPMAlgECC,
-			digest:  		crypto.SHA256,
-			bits:    		256,
-			ownerpassword: 	ownerPassword,
+			msg:           "ecdsa - test encryption/decrypt - no pin",
+			filekey:       []byte("this is a test filekey"),
+			keytype:       tpm2.TPMAlgECC,
+			digest:        crypto.SHA256,
+			bits:          256,
+			ownerpassword: ownerPassword,
 		},
 		{
-			msg:     		"ecdsa - test encryption/decrypt - pin",
-			filekey: 		[]byte("this is a test filekey"),
-			pin:     		[]byte("123"),
-			signpin: 		[]byte("123"),
-			keytype: 		tpm2.TPMAlgECC,
-			digest:  		crypto.SHA256,
-			bits:    		256,
-			ownerpassword: 	ownerPassword,
+			msg:           "ecdsa - test encryption/decrypt - pin",
+			filekey:       []byte("this is a test filekey"),
+			pin:           []byte("123"),
+			signpin:       []byte("123"),
+			keytype:       tpm2.TPMAlgECC,
+			digest:        crypto.SHA256,
+			bits:          256,
+			ownerpassword: ownerPassword,
 		},
 		{
-			msg:     		"ecdsa - test encryption/decrypt - no pin - invalid owner password",
-			filekey: 		[]byte("this is a test filekey"),
-			keytype: 		tpm2.TPMAlgECC,
-			digest:  		crypto.SHA256,
-			bits:    		256,
-			shouldfail:		true,
-			ownerpassword: 	[]byte("invalidPassword"),
+			msg:           "ecdsa - test encryption/decrypt - no pin - invalid owner password",
+			filekey:       []byte("this is a test filekey"),
+			keytype:       tpm2.TPMAlgECC,
+			digest:        crypto.SHA256,
+			bits:          256,
+			shouldfail:    true,
+			ownerpassword: []byte("invalidPassword"),
 		},
 	}
 
@@ -235,7 +236,7 @@ func TestSigningWithOwnerPassword(t *testing.T) {
 			h.Write([]byte("heyho"))
 			b := h.Sum(nil)
 
-			k, err := key.CreateKey(tpm, c.keytype, c.bits, c.ownerpassword, c.pin, "")
+			k, err := key.CreateKey(tpm, c.keytype, c.bits, c.ownerpassword, 0x0, c.pin, "")
 			if err != nil {
 				if c.shouldfail {
 					return
@@ -245,6 +246,7 @@ func TestSigningWithOwnerPassword(t *testing.T) {
 
 			signer := NewTPMSigner(k,
 				func() ([]byte, error) { return c.ownerpassword, nil },
+				0x0,
 				func() transport.TPMCloser { return tpm },
 				func(_ *key.Key) ([]byte, error) { return c.signpin, nil },
 			)
@@ -374,13 +376,14 @@ func TestSigningWithImportedKey(t *testing.T) {
 				pk = *p
 			}
 
-			k, err := key.ImportKey(tpm, []byte(""), pk, c.pin, "")
+			k, err := key.ImportKey(tpm, []byte(""), 0x0, pk, c.pin, "")
 			if err != nil {
 				t.Fatalf("failed key import: %v", err)
 			}
 
 			signer := NewTPMSigner(k,
 				func() ([]byte, error) { return []byte(""), nil },
+				0x0,
 				func() transport.TPMCloser { return tpm },
 				func(_ *key.Key) ([]byte, error) { return c.signpin, nil },
 			)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"github.com/foxboron/ssh-tpm-agent/contrib"
+	"github.com/google/go-tpm/tpm2"
 	"html/template"
 	"io/fs"
 	"os"
 	"path"
+	"strconv"
 )
 
 func SSHDir() string {
@@ -138,4 +140,17 @@ func InstallSshdConf() error {
 	}
 	fmt.Println("Restart sshd: systemd restart sshd")
 	return nil
+}
+
+func ParseHexHandle(handleString string) (tpm2.TPMHandle, error) {
+	if len(handleString) > 2 && handleString[0:2] == "0x" {
+		handleString = handleString[2:]
+	}
+
+	result, err := strconv.ParseUint(handleString, 16, 32)
+	if err != nil {
+		return 0x0, fmt.Errorf("failed parsing handle: %v", err)
+	}
+
+	return tpm2.TPMHandle(result), nil
 }


### PR DESCRIPTION
* Persisting the SRK allows the creation and use of individual keys without specifying the owner password

Example:

1. Set an owner password: tpm2_changeauth -c owner myPass
2. Create SSH key and save SRK to handle ID 0x81000002: ssh-tpm-keygen -o -s 0x81000002
3. Create another SSH key without entering the owner password: ssh-tpm-keygen -s 0x81000002
4. Start the SSH agent without entering the owner password: /ssh-tpm-agent -s 0x81000002 -l /var/tmp/tpm.sock

Based on #37 