### PR TITLE
ssh-tpm-keygen: set default number of bits for ecdsa and rsa

### DIFF
--- a/cmd/ssh-tpm-keygen/main.go
+++ b/cmd/ssh-tpm-keygen/main.go
@@ -142,6 +142,15 @@ func main() {
 	}
 	defer tpm.Close()
 
+	if bits == 0 {
+		if keyType == "ecdsa" {
+			bits = 256
+		}
+		if keyType == "rsa" {
+			bits = 2048
+		}
+	}
+
 	supportedECCBitsizes := key.SupportedECCAlgorithms(tpm)
 
 	if listsupported {


### PR DESCRIPTION
When calling ssh-tpm-agent without `-b` the number of bits defaults to 0, leading to:
```
  invalid ecdsa key length: TPM does not support 0 bits
```
This sets the default number of bits to 256 for ecdsa and or 2048 for rsa.

Closes #42