### PR TITLE
contrib/services/user/ssh-tpm-agent.service: fix SSH_AUTH_SOCK path

### DIFF
--- a/contrib/services/user/ssh-tpm-agent.service
+++ b/contrib/services/user/ssh-tpm-agent.service
@@ -5,7 +5,7 @@ Documentation=man:ssh-agent(1) man:ssh-add(1) man:ssh(1)
 Requires=ssh-tpm-agent.socket
 
 [Service]
-Environment=SSH_AUTH_SOCK=%t/ssh-tpm-agent.socket
+Environment=SSH_AUTH_SOCK=%t/ssh-tpm-agent.sock
 ExecStart={{.GoBinary}}
 PassEnvironment=SSH_AGENT_PID
 SuccessExitStatus=2


### PR DESCRIPTION
ssh-tpm-agent defaults to `$XDG_RUNTIME_DIR/ssh-tpm-agent.sock`.