### PR TITLE
Use passphrase terminology, not PIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Alternatively download the [pre-built binaries](https://github.com/Foxboron/ssh-
 $ ssh-tpm-keygen
 Generating a sealed public/private ecdsa key pair.
 Enter file in which to save the key (/home/fox/.ssh/id_ecdsa):
-Enter pin (empty for no pin):
-Enter same pin again:
+Enter passphrase (empty for no passphrase):
+Enter same passphrase again:
 Your identification has been saved in /home/fox/.ssh/id_ecdsa.tpm
 Your public key has been saved in /home/fox/.ssh/id_ecdsa.pub
 The key fingerprint is:
@@ -102,8 +102,8 @@ The key's randomart image is:
 # Import the key
 $ ssh-tpm-keygen --import id_ecdsa
 Sealing an existing public/private ecdsa key pair.
-Enter pin (empty for no pin):
-Confirm pin:
+Enter passphrase (empty for no passphrase):
+Confirm passphrase:
 Your identification has been saved in id_ecdsa.tpm
 The key fingerprint is:
 SHA256:bDn2EpX6XRX5ADXQSuTq+uUyia/eV3Z6MW+UtxjnXvU
@@ -152,8 +152,8 @@ ssh-rsa AAAAB3NzaC1yc[...]8TWynQ== ssh-agent
 $ ssh-tpm-keygen -C ssh-tpm-agent
 Generating a sealed public/private ecdsa key pair.
 Enter file in which to save the key (/home/fox/.ssh/id_ecdsa):
-Enter pin (empty for no pin):
-Confirm pin:
+Enter passphrase (empty for no passphrase):
+Confirm passphrase:
 Your identification has been saved in /home/fox/.ssh/id_ecdsa.tpm
 Your public key has been saved in /home/fox/.ssh/id_ecdsa.pub
 The key fingerprint is:

--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ testing.
 
 ## Installation
 
-The simplest way of installing this plugin is by running the follow go command.
+The simplest way of installing this plugin is by running the following:
 
-`go install github.com/foxboron/ssh-tpm-agent/cmd/...@latest`
+```bash
+go install github.com/foxboron/ssh-tpm-agent/cmd/...@latest
+```
 
 Alternatively download the [pre-built binaries](https://github.com/Foxboron/ssh-tpm-agent/releases).
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The key's randomart image is:
 $ ssh-tpm-keygen --import id_ecdsa
 Sealing an existing public/private ecdsa key pair.
 Enter passphrase (empty for no passphrase):
-Confirm passphrase:
+Enter same passphrase again:
 Your identification has been saved in id_ecdsa.tpm
 The key fingerprint is:
 SHA256:bDn2EpX6XRX5ADXQSuTq+uUyia/eV3Z6MW+UtxjnXvU

--- a/cmd/ssh-tpm-keygen/main.go
+++ b/cmd/ssh-tpm-keygen/main.go
@@ -36,7 +36,7 @@ Options:
     -o, --owner-password        Ask for the owner password.
     -C                          Provide a comment with the key.
     -f                          Output keyfile.
-    -N                          PIN for the key.
+    -N                          passphrase for the key.
     -t ecdsa | rsa              Specify the type of key to create. Defaults to ecdsa
     -b bits                     Number of bits in the key to create.
                                     rsa: 2048 (default)
@@ -65,8 +65,8 @@ Example:
     $ ssh-tpm-keygen
     Generating a sealed public/private ecdsa key pair.
     Enter file in which to save the key (/home/user/.ssh/id_ecdsa):
-    Enter pin (empty for no pin):
-    Enter same pin again:
+    Enter passphrase (empty for no passphrase):
+    Enter same passphrase again:
     Your identification has been saved in /home/user/.ssh/id_ecdsa.tpm
     Your public key has been saved in /home/user/.ssh/id_ecdsa.pub
     The key fingerprint is:
@@ -75,11 +75,11 @@ Example:
 
 func getPin() ([]byte, error) {
 	for {
-		pin1, err := askpass.ReadPassphrase("Enter pin (empty for no pin): ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
+		pin1, err := askpass.ReadPassphrase("Enter passphrase (empty for no passphrase): ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
 		if err != nil {
 			return nil, err
 		}
-		pin2, err := askpass.ReadPassphrase("Confirm pin: ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
+		pin2, err := askpass.ReadPassphrase("Confirm passphrase: ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
 		if err != nil {
 			return nil, err
 		}
@@ -146,12 +146,12 @@ func main() {
 	flag.BoolVar(&askOwnerPassword, "owner-password", false, "ask for the owner password")
 	flag.StringVar(&comment, "C", defaultComment, "provide a comment, default to user@host")
 	flag.StringVar(&outputFile, "f", "", "output keyfile")
-	flag.StringVar(&keyPin, "N", "", "new pin for the key")
+	flag.StringVar(&keyPin, "N", "", "new passphrase for the key")
 	flag.StringVar(&keyType, "t", "ecdsa", "key to create")
 	flag.IntVar(&bits, "b", 0, "number of bits")
 	flag.StringVar(&importKey, "I", "", "import key")
 	flag.StringVar(&importKey, "import", "", "import key")
-	flag.BoolVar(&changePin, "p", false, "change pin")
+	flag.BoolVar(&changePin, "p", false, "change passphrase")
 	flag.BoolVar(&swtpmFlag, "swtpm", false, "use swtpm instead of actual tpm")
 	flag.BoolVar(&hostKeys, "A", false, "generate host keys")
 	flag.BoolVar(&listsupported, "supported", false, "list tpm caps")
@@ -323,7 +323,7 @@ func main() {
 		rawKey, err = ssh.ParseRawPrivateKey(pem)
 		if errors.As(err, &kerr) {
 			for {
-				pin, err := askpass.ReadPassphrase("Enter existing password (empty for no pin): ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
+				pin, err := askpass.ReadPassphrase("Enter existing passphrase (empty for no passphrase): ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -331,7 +331,7 @@ func main() {
 				if err == nil {
 					break
 				} else if errors.Is(err, x509.IncorrectPasswordError) {
-					fmt.Println("Wrong password, try again.")
+					fmt.Println("Wrong passphrase, try again.")
 					continue
 				} else {
 					log.Fatal(err)
@@ -425,32 +425,32 @@ func main() {
 			filename = string(f)
 		}
 
-		oldPin, err := askpass.ReadPassphrase("Enter old pin: ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
+		oldPin, err := askpass.ReadPassphrase("Enter old passphrase: ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
 		if err != nil {
 			log.Fatal(err)
 		}
-		newPin, err := askpass.ReadPassphrase("Enter new pin (empty for no pin): ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
+		newPin, err := askpass.ReadPassphrase("Enter new passphrase (empty for no passphrase): ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
 		if err != nil {
 			log.Fatal(err)
 		}
-		newPin2, err := askpass.ReadPassphrase("Enter same pin: ", askpass.RP_ALLOW_STDIN)
+		newPin2, err := askpass.ReadPassphrase("Enter same passphrase: ", askpass.RP_ALLOW_STDIN)
 		if err != nil {
 			log.Fatal(err)
 		}
 		if !bytes.Equal(newPin, newPin2) {
-			log.Fatal("Pin do not match. Try again.")
+			log.Fatal("Passphrases do not match. Try again.")
 		}
 		fmt.Println()
 
 		if err := keyfile.ChangeAuth(tpm, ownerPassword, k.TPMKey, oldPin, newPin); err != nil {
-			log.Fatal("Failed changing pin on the key.")
+			log.Fatal("Failed changing passphrase on the key.")
 		}
 
 		if err := os.WriteFile(filename, k.Bytes(), 0o600); err != nil {
 			log.Fatal(err)
 		}
 
-		fmt.Println("Your identification has been saved with the new pin.")
+		fmt.Println("Your identification has been saved with the new passphrase.")
 		os.Exit(0)
 	}
 
@@ -485,7 +485,7 @@ func main() {
 			rawKey, err = ssh.ParseRawPrivateKey(pem)
 			if errors.As(err, &kerr) {
 				for {
-					pin, err := askpass.ReadPassphrase("Enter existing password (empty for no pin): ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
+					pin, err := askpass.ReadPassphrase("Enter existing passphrase (empty for no passphrase): ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
 					if err != nil {
 						log.Fatal(err)
 					}
@@ -493,7 +493,7 @@ func main() {
 					if err == nil {
 						break
 					} else if errors.Is(err, x509.IncorrectPasswordError) {
-						fmt.Println("Wrong password, try again.")
+						fmt.Println("Wrong passphrase, try again.")
 						continue
 					} else {
 						log.Fatal(err)

--- a/cmd/ssh-tpm-keygen/main.go
+++ b/cmd/ssh-tpm-keygen/main.go
@@ -79,7 +79,7 @@ func getPin() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		pin2, err := askpass.ReadPassphrase("Confirm passphrase: ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
+		pin2, err := askpass.ReadPassphrase("Enter same passphrase: ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/ssh-tpm-keygen/main.go
+++ b/cmd/ssh-tpm-keygen/main.go
@@ -79,7 +79,7 @@ func getPin() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		pin2, err := askpass.ReadPassphrase("Enter same passphrase: ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
+		pin2, err := askpass.ReadPassphrase("Enter same passphrase again: ", askpass.RP_ALLOW_STDIN|askpass.RP_NEWLINE)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
As part of https://github.com/Foxboron/ssh-tpm-agent/commit/f8a5360393a33c7b162cb323ad09ced5a9d0738f, you used the phrasing passphrase, not PIN; and the usage seems inconsistent throughout.

This pull request replaces any usage of `pin` with `passphrase` (or `pass` internally), such that the usage and terminology (and stdout output) is somewhat consistent with `ssh-keygen`.

I think pointing out that TPM 2.0 has well defined anti-hammering protection is informative as to the type of passphrase you could use compared to hinting specifically that you have PIN support; which nearly sounds like a limitation to me than a feature.

However I am not too opinionated on keeping [ce6edea](https://github.com/Foxboron/ssh-tpm-agent/pull/57/commits/ce6edea8c8c15d79cacff4646cca87e729e859e9) in this pull request if you feel otherwise.