### PR TITLE
fix add ssh certificate with existing key

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -68,11 +68,11 @@ func (a *Agent) AddTPMKey(addedkey []byte) ([]byte, error) {
 		Certificate: addkey.Certificate,
 	}
 
-	if slices.ContainsFunc(a.keys, func(kk *key.SSHTPMKey) bool {
+	// delete the key if it already exists in the list
+	// it may have been loaded with no certificate or an old certificate
+	a.keys = slices.DeleteFunc(a.keys, func(kk *key.SSHTPMKey) bool {
 		return kk.Fingerprint() == k.Fingerprint()
-	}) {
-		return []byte(""), nil
-	}
+	})
 
 	a.keys = append(a.keys, k)
 


### PR DESCRIPTION
Currently you cannot add or update a certificate if the key has already been loaded because `AddTPMKey` will exit if the public key fingerprint matches an existing key. It ignores the certificate that was provided in the request.

Let's unconditionally replace the key so that the certificate attribute will be updated.

This enables using short lived ssh certificates which are common in enterprise environments. These certificates typically expire in a few hours.

One notable thing that will still not work is having multiple certificates per key. This can happen if there are multiple authorities in your organization or a authority rotation is in progress. These scenarios could be tolerated, but I think we should just do a simple fix for now.