### PR TITLE
Fix build with go 1.23

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -300,7 +300,7 @@ func (a *Agent) Remove(sshkey ssh.PublicKey) error {
 	for _, agent := range a.agents {
 		lkeys, err := agent.List()
 		if err != nil {
-			slog.Debug("agent returned err on List(): %v", err)
+			slog.Debug("agent returned err on List()", slog.Any("err", err))
 			continue
 		}
 
@@ -309,7 +309,7 @@ func (a *Agent) Remove(sshkey ssh.PublicKey) error {
 				continue
 			}
 			if err := agent.Remove(sshkey); err != nil {
-				slog.Debug("agent returned err on Remove(): %v", err)
+				slog.Debug("agent returned err on Remove()", slog.Any("err", err))
 			}
 			slog.Debug("deleting key from an proxy agent", slog.String("fingerprint", fp))
 			return nil


### PR DESCRIPTION
go 1.23 makes this vet warning fatal:

```
➜  ssh-tpm-agent git:(add-certificate) ✗ go vet ./...
# github.com/foxboron/ssh-tpm-agent/agent
# [github.com/foxboron/ssh-tpm-agent/agent]
agent/agent.go:303:51: slog.Debug arg "err" should be a string or a slog.Attr (possible missing key or value)
agent/agent.go:312:54: slog.Debug arg "err" should be a string or a slog.Attr (possible missing key or value)
```

