### PR TITLE
agent: Don't overwrite SSH_AUTH_SOCK socket

### DIFF
--- a/cmd/ssh-tpm-agent/main.go
+++ b/cmd/ssh-tpm-agent/main.go
@@ -110,7 +110,8 @@ func main() {
 	)
 
 	envSocketPath := func() string {
-		if val, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok && socketPath == "" {
+		// Find a default socket name from ssh-tpm-agent.service
+		if val, ok := os.LookupEnv("SSH_TPM_AUTH_SOCK"); ok && socketPath == "" {
 			return val
 		}
 

--- a/contrib/services/user/ssh-tpm-agent.service
+++ b/contrib/services/user/ssh-tpm-agent.service
@@ -5,7 +5,7 @@ Documentation=man:ssh-agent(1) man:ssh-add(1) man:ssh(1)
 Requires=ssh-tpm-agent.socket
 
 [Service]
-Environment=SSH_AUTH_SOCK=%t/ssh-tpm-agent.sock
+Environment=SSH_TPM_AUTH_SOCK=%t/ssh-tpm-agent.sock
 ExecStart={{.GoBinary}}
 PassEnvironment=SSH_AGENT_PID
 SuccessExitStatus=2


### PR DESCRIPTION
In c1206e1a09d7 ("ssh-tpm-agent: use SSH_AUTH_SOCK") ssh-tpm-agent started using SSH_AUTH_SOCK as the default path. That is problematic because it will overwrite the existing socket, so -A won't work any more. Instead use a distinct environment variable passed from the .service file.