### PR TITLE
when keyring returns ENOENT, treat it as ENOKEY

### DIFF
--- a/cmd/ssh-tpm-agent/main.go
+++ b/cmd/ssh-tpm-agent/main.go
@@ -259,7 +259,11 @@ func main() {
 				slog.Debug("providing cached userauth for key", slog.String("fp", key.Fingerprint()))
 				// TODO: This is not great, but easier for now
 				return auth.Read(), nil
-			} else if errors.Is(err, syscall.ENOKEY) || errors.Is(err, syscall.EACCES) {
+			} else if errors.Is(err, syscall.ENOKEY) || errors.Is(err, syscall.EACCES) || errors.Is(err, syscall.ENOENT) {
+				if errors.Is(err, syscall.ENOENT) {
+					slog.Warn("kernel is missing the keyctl executable helpers. Please install the keyutils package to use the agent with caching.")
+				}
+
 				keyInfo := fmt.Sprintf("Enter passphrase for (%s): ", key.GetDescription())
 				// TODOt kjk: askpass should box the byte slice
 				userauth, err := askpass.ReadPassphrase(keyInfo, askpass.RP_USE_ASKPASS)


### PR DESCRIPTION
I get this error on this kernel:

Jun 02 15:26:27 turingmachine systemd[2442]: Started SSH Agent.
Jun 02 15:26:27 turingmachine ssh-tpm-agent[110960]: time=2025-06-02T15:26:27.740+02:00 level=INFO msg="Activated agent by socket"
Jun 02 15:27:00 turingmachine ssh-tpm-agent[110960]: time=2025-06-02T15:27:00.135+02:00 level=INFO msg="agent 13: failed getting pin for key: no such file or directory"


$ uname -a
Linux turingmachine 6.14.8 #1-NixOS SMP PREEMPT_DYNAMIC Thu May 22 12:31:58 UTC 2025 x86_64 GNU/Linux

It overall seems that caching doesn't seem to work for me with the kernel, but it's better to be able to type in the password instead of breaking ssh-agent-tpm

Open for better suggestions, but I need to have something working now, so I will use this patch until than.