### PR TITLE
Embed version in git-archive tarballs and populate VERSION from it when set

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.tarball-version-git export-subst

--- a/.tarball-version-git
+++ b/.tarball-version-git
@@ -1,0 +1,1 @@
+$Format:%(describe)$

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHRDIR := $(PREFIX)/share
 MANDIR := $(PREFIX)/share/man
 BINS = $(filter-out %_test.go,$(notdir $(wildcard cmd/*)))
 TAG = $(shell git describe --abbrev=0 --tags)
-VERSION = $(shell git describe --abbrev=7 | sed 's/-/./g;s/^v//;')
+VERSION = $(shell if grep Format .tarball-version-git > /dev/null; then git describe --abbrev=7 | sed 's/-/./g;s/^v//;'; else cat .tarball-version-git; fi)
 
 MANPAGES = \
 	man/ssh-tpm-hostkeys.1 \


### PR DESCRIPTION
Here is an idea for this -- it works if the tarballs are created by 'git archive', for example like this:

```
git archive --prefix=ssh-tpm-agent-$(git describe --abbrev=7)/ -o ssh-tpm-agent-$(git describe --abbrev=7)-src.tar.gz HEAD
```

Some git hosting sites supports `.gitattribute` `$Format$` export substitution, not sure about GitHub.

Cheers,
Simon

Closes: #90