### PR TITLE
fix: ssh-tpm-keygen for empty passphrase

### DIFF
--- a/cmd/ssh-tpm-keygen/main.go
+++ b/cmd/ssh-tpm-keygen/main.go
@@ -195,7 +195,9 @@ func doChangePin(tpm transport.TPMCloser, passphrase, keyPin, ownerPassword []by
 		if err != nil {
 			return err
 		}
-		filename = string(f)
+		if string(f) != "" {
+			filename = string(f)
+		}
 	}
 
 	if len(passphrase) == 0 {


### PR DESCRIPTION
From what (little...) I understand of the flow of the code here,

I suspect that this fixes what https://github.com/Foxboron/ssh-tpm-agent/pull/119#discussion_r3025581529 raised?

@Foxboron 