### PR TITLE
ssh-tpm-agent: add `--confirm-loaded` flag

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -457,7 +457,7 @@ func (a *Agent) Unlock(passphrase []byte) error {
 	return ErrOperationUnsupported
 }
 
-func LoadKeys(keyDir string) ([]key.SSHTPMKeys, error) {
+func LoadKeys(keyDir string, confirm bool) ([]key.SSHTPMKeys, error) {
 	keyDir, err := filepath.EvalSymlinks(keyDir)
 	if err != nil {
 		return nil, err
@@ -493,6 +493,8 @@ func LoadKeys(keyDir string) ([]key.SSHTPMKeys, error) {
 			}
 			return nil
 		}
+
+		k.ConfirmBeforeUse = confirm
 
 		keys = append(keys, k)
 		slog.Debug("added TPM key", slog.String("name", path))

--- a/cmd/ssh-tpm-agent/main.go
+++ b/cmd/ssh-tpm-agent/main.go
@@ -46,6 +46,8 @@ Options:
 
     --no-load              Do not load TPM sealed keys by default.
 
+    --confirm-loaded       Require confirmation via SSH_ASKPASS for all preloaded keys.
+
     -o, --owner-password   Ask for the owner password.
 
     --no-cache             The agent will not cache key passwords.
@@ -114,6 +116,7 @@ func main() {
 		socketPath, keyDir               string
 		swtpmFlag, printSocketFlag       bool
 		installUserUnits, system, noLoad bool
+		confirmLoaded                    bool
 		askOwnerPassword, debugMode      bool
 		noCache                          bool
 		hierarchy                        string
@@ -129,6 +132,7 @@ func main() {
 	flag.BoolVar(&installUserUnits, "install-user-units", false, "install systemd user units")
 	flag.BoolVar(&system, "install-system", false, "install systemd user units")
 	flag.BoolVar(&noLoad, "no-load", false, "don't load TPM sealed keys")
+	flag.BoolVar(&confirmLoaded, "confirm-loaded", false, "require confirmation for all preloaded keys")
 	flag.BoolVar(&askOwnerPassword, "o", false, "ask for the owner password")
 	flag.BoolVar(&askOwnerPassword, "owner-password", false, "ask for the owner password")
 	flag.BoolVar(&debugMode, "d", false, "debug mode")
@@ -211,7 +215,7 @@ func main() {
 	// We need to pre-read all the keys before we run landlock
 	var keys []key.SSHTPMKeys
 	if !noLoad {
-		keys, err = agent.LoadKeys(keyDir)
+		keys, err = agent.LoadKeys(keyDir, confirmLoaded)
 		if err != nil {
 			log.Fatalf("can't preload keys from ~/.ssh: %v", err)
 		}

--- a/man/ssh-tpm-agent.1.adoc
+++ b/man/ssh-tpm-agent.1.adoc
@@ -40,6 +40,9 @@ Defaults to _~/.ssh_.
 *--no-load*::
   Do not load TPM sealed keys from _~/.ssh_ by default.
 
+*--confirm-loaded*::
+  Require confirmation via _SSH_ASKPASS_ for all preloaded keys.
+
 *-o, --owner-password*::
   Ask for the owner password.
 


### PR DESCRIPTION
If set, this flag automatically adds the confirmation requirement to all the keys preloaded from `--key-dir`.

Alternatively, one could of course use the `--no-load` flag and then `ssh-tpm-add -c` all keys manually, but I think it would be nice to have a dedicated flag for this.