### PR TITLE
askpass: add gnome-ssh-askpass4 to search list

### DIFF
--- a/askpass/askpass.go
+++ b/askpass/askpass.go
@@ -42,6 +42,7 @@ var (
 	// Default ASKPASS programs
 	SSH_ASKPASS_DEFAULTS = []string{
 		"/usr/lib/ssh/x11-ssh-askpass",
+		"/usr/lib/ssh/gnome-ssh-askpass4",
 		"/usr/lib/ssh/gnome-ssh-askpass3",
 		"/usr/lib/ssh/gnome-ssh-askpass",
 		"/usr/libexec/openssh/gnome-ssh-askpass",


### PR DESCRIPTION
Hi,

I was browsing around for an askpass variant that integrates better into a modern Gnome environment than the one that's shipped with Seahorse, something that also supports the `SSH_ASKPASS_PROMPT` for the confirmation feature, and found [gnome-ssh-askpass4](https://github.com/openssh/openssh-portable/blob/master/contrib/gnome-ssh-askpass4.c) on [AUR](https://aur.archlinux.org/packages/gnome-ssh-askpass4-git). This PR adds it to the default search list.

Thanks