### PR TITLE
keyring: use KeyctlSearch

### DIFF
--- a/cmd/ssh-tpm-agent/main.go
+++ b/cmd/ssh-tpm-agent/main.go
@@ -260,9 +260,6 @@ func main() {
 		func(key key.SSHTPMKeys) ([]byte, error) {
 			auth, err := agentkeyring.ReadKey(key.Fingerprint())
 			switch {
-			case errors.Is(err, syscall.ENOENT):
-				slog.Warn("kernel is missing the keyctl executable helpers. Please install the keyutils package to use the agent with caching.")
-				fallthrough
 			case errors.Is(err, syscall.ENOKEY) || errors.Is(err, syscall.EACCES):
 				keyInfo := fmt.Sprintf("Enter passphrase for (%s): ", key.GetDescription())
 				// TODO: askpass should box the byte slice

--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -35,7 +35,7 @@ func (k *Keyring) AddKey(name string, b []byte) error {
 
 func (k *Keyring) ReadKey(name string) (*Key, error) {
 	slog.Debug("readkey", slog.String("name", name))
-	id, err := unix.RequestKey("user", name, "", k.ringid)
+	id, err := unix.KeyctlSearch(k.ringid, "user", name, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (k *Keyring) ReadKey(name string) (*Key, error) {
 
 func (k *Keyring) RemoveKey(name string) error {
 	slog.Debug("removekey", slog.String("name", name))
-	id, err := unix.RequestKey("user", name, "", k.ringid)
+	id, err := unix.KeyctlSearch(k.ringid, "user", name, 0)
 	if err != nil {
 		return fmt.Errorf("failed remove-key: %v", err)
 	}


### PR DESCRIPTION
[keyring: use KEYCTL_SEARCH instead of request_key(2)](https://github.com/Foxboron/ssh-tpm-agent/commit/903ded28195cbd92e1a88812f49329a8dd688f29)

[cmd/ssh-tpm-agent: drop ENOENT handling for cache misses](https://github.com/Foxboron/ssh-tpm-agent/commit/7406e54ed6827191c58312454f35a9e233f6910b)