### PR TITLE
fix: ensure cached passphrase buffer is freed

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -42,7 +42,7 @@ type Agent struct {
 	mu       sync.Mutex
 	tpm      func() transport.TPMCloser
 	op       func() ([]byte, error)
-	pin      func(key.SSHTPMKeys) ([]byte, error)
+	pin      func(key.SSHTPMKeys) ([]byte, *keyring.Key, error)
 	listener *net.UnixListener
 	quit     chan any
 	wg       sync.WaitGroup
@@ -119,7 +119,7 @@ func (a *Agent) signers() ([]ssh.Signer, error) {
 	for _, k := range a.keys {
 		s, err := ssh.NewSignerFromSigner(k.Signer(
 			a.keyring(), a.op, a.tpm,
-			func(_ *keyfile.TPMKey) ([]byte, error) {
+			func(_ *keyfile.TPMKey) ([]byte, *keyring.Key, error) {
 				// Shimming the function to get the correct type
 				return a.pin(k)
 			}),
@@ -526,7 +526,7 @@ func LoadKeys(keyDir string, confirm bool) ([]key.SSHTPMKeys, error) {
 	return keys, err
 }
 
-func NewAgent(listener *net.UnixListener, agents []agent.ExtendedAgent, keyring func() *keyring.ThreadKeyring, tpmFetch func() transport.TPMCloser, ownerPassword func() ([]byte, error), pin func(key.SSHTPMKeys) ([]byte, error)) *Agent {
+func NewAgent(listener *net.UnixListener, agents []agent.ExtendedAgent, keyring func() *keyring.ThreadKeyring, tpmFetch func() transport.TPMCloser, ownerPassword func() ([]byte, error), pin func(key.SSHTPMKeys) ([]byte, *keyring.Key, error)) *Agent {
 	a := &Agent{
 		agents:   agents,
 		tpm:      tpmFetch,

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -45,7 +45,7 @@ func TestAddKey(t *testing.T) {
 		// Owner password
 		func() ([]byte, error) { return []byte(""), nil },
 		// PIN Callback
-		func(_ key.SSHTPMKeys) ([]byte, error) { return []byte(""), nil },
+		func(_ key.SSHTPMKeys) ([]byte, *keyring.Key, error) { return []byte(""), nil, nil },
 	)
 	defer ag.Stop()
 

--- a/cmd/ssh-tpm-agent/main.go
+++ b/cmd/ssh-tpm-agent/main.go
@@ -257,27 +257,26 @@ func main() {
 		// PIN Callback with caching
 		// SSHKeySigner in signer/signer.go resets this value if
 		// we get a TPMRCAuthFail
-		func(key key.SSHTPMKeys) ([]byte, error) {
+		// TODO: this should only return the boxed key in the future
+		func(key key.SSHTPMKeys) ([]byte, *keyring.Key, error) {
 			auth, err := agentkeyring.ReadKey(key.Fingerprint())
 			switch {
 			case errors.Is(err, syscall.ENOKEY) || errors.Is(err, syscall.EACCES):
 				keyInfo := fmt.Sprintf("Enter passphrase for (%s): ", key.GetDescription())
 				// TODO: askpass should box the byte slice
 				userauth, err := askpass.ReadPassphrase(keyInfo, askpass.RP_USE_ASKPASS)
-				fmt.Println(err)
 				if !noCache && err == nil {
 					slog.Debug("caching userauth for key in keyring", slog.String("fp", key.Fingerprint()))
 					if err := agentkeyring.AddKey(key.Fingerprint(), userauth); err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 				}
-				return userauth, err
+				return userauth, nil, err
 			case err == nil:
 				slog.Debug("providing cached userauth for key", slog.String("fp", key.Fingerprint()))
-				// TODO: This is not great, but easier for now
-				return auth.Read(), nil
+				return auth.Read(), auth, nil
 			}
-			return nil, fmt.Errorf("failed getting pin for key: %w", err)
+			return nil, nil, fmt.Errorf("failed getting pin for key: %w", err)
 		},
 	)
 

--- a/cmd/ssh-tpm-agent/main_test.go
+++ b/cmd/ssh-tpm-agent/main_test.go
@@ -144,8 +144,8 @@ func runSSHAuth(t *testing.T, keytype tpm2.TPMAlgID, bits int, pin []byte, keyfn
 		// Owner password
 		func() ([]byte, error) { return []byte(""), nil },
 		// PIN Callback
-		func(_ key.SSHTPMKeys) ([]byte, error) {
-			return pin, nil
+		func(_ key.SSHTPMKeys) ([]byte, *keyring.Key, error) {
+			return pin, nil, nil
 		},
 	)
 	defer ag.Stop()

--- a/cmd/ssh-tpm-agent/testdata/script/agent_password.txt
+++ b/cmd/ssh-tpm-agent/testdata/script/agent_password.txt
@@ -18,6 +18,15 @@ exec ssh-keygen -Y sign -n file -f .ssh/id_ecdsa.pub file_to_sign.txt
 stdin file_to_sign.txt
 exec ssh-keygen -Y check-novalidate -n file -f .ssh/id_ecdsa.pub -s file_to_sign.txt.sig
 exists file_to_sign.txt.sig
+
+# Sign a second time to validate pin caching, removing askpass to ensure no prompt occurs
+rm askpass-test
+rm file_to_sign.txt.sig
+exec ssh-keygen -Y sign -n file -f .ssh/id_ecdsa.pub file_to_sign.txt
+stdin file_to_sign.txt
+exec ssh-keygen -Y check-novalidate -n file -f .ssh/id_ecdsa.pub -s file_to_sign.txt.sig
+exists file_to_sign.txt.sig
+
 exec ssh-add -D
 rm file_to_sign.txt.sig
 rm .ssh/id_ecdsa.tpm .ssh/id_ecdsa.pub

--- a/internal/keytest/keytest.go
+++ b/internal/keytest/keytest.go
@@ -121,8 +121,8 @@ func NewTestAgent(t *testing.T, tpm transport.TPMCloser) *agent.Agent {
 		func() *keyring.ThreadKeyring { return &keyring.ThreadKeyring{} },
 		func() transport.TPMCloser { return tpm },
 		func() ([]byte, error) { return []byte(""), nil },
-		func(_ key.SSHTPMKeys) ([]byte, error) {
-			return []byte(""), nil
+		func(_ key.SSHTPMKeys) ([]byte, *keyring.Key, error) {
+			return []byte(""), nil, nil
 		},
 	)
 }

--- a/key/hierarchy_keys.go
+++ b/key/hierarchy_keys.go
@@ -156,7 +156,7 @@ func (h *HierSSHTPMKey) FlushHandle(tpm transport.TPMCloser) {
 	}
 }
 
-func (h *HierSSHTPMKey) Signer(keyring *keyring.ThreadKeyring, ownerAuth func() ([]byte, error), tpm func() transport.TPMCloser, auth func(*keyfile.TPMKey) ([]byte, error)) *SSHKeySigner {
+func (h *HierSSHTPMKey) Signer(keyring *keyring.ThreadKeyring, ownerAuth func() ([]byte, error), tpm func() transport.TPMCloser, auth func(*keyfile.TPMKey) ([]byte, *keyring.Key, error)) *SSHKeySigner {
 	return NewSSHKeySigner(h, keyring, ownerAuth, tpm, auth)
 }
 

--- a/key/hierarchy_keys_test.go
+++ b/key/hierarchy_keys_test.go
@@ -70,7 +70,7 @@ func TestHierKeySigner(t *testing.T) {
 	signer := hkey.Signer(&keyring.ThreadKeyring{},
 		func() ([]byte, error) { return []byte(nil), nil },
 		func() transport.TPMCloser { return tpm },
-		func(_ *keyfile.TPMKey) ([]byte, error) { return []byte(nil), nil },
+		func(_ *keyfile.TPMKey) ([]byte, *keyring.Key, error) { return []byte(nil), nil, nil },
 	)
 	h := crypto.SHA256.New()
 	h.Write([]byte("message"))

--- a/key/key.go
+++ b/key/key.go
@@ -19,7 +19,7 @@ var (
 )
 
 type SSHTPMKeys interface {
-	Signer(*keyring.ThreadKeyring, func() ([]byte, error), func() transport.TPMCloser, func(*keyfile.TPMKey) ([]byte, error)) *SSHKeySigner
+	Signer(*keyring.ThreadKeyring, func() ([]byte, error), func() transport.TPMCloser, func(*keyfile.TPMKey) ([]byte, *keyring.Key, error)) *SSHKeySigner
 	GetDescription() string
 	Fingerprint() string
 	AuthorizedKey() []byte
@@ -124,7 +124,7 @@ func (k *SSHTPMKey) GetConfirmBeforeUse() bool {
 	return k.ConfirmBeforeUse
 }
 
-func (k *SSHTPMKey) Signer(keyring *keyring.ThreadKeyring, ownerAuth func() ([]byte, error), tpm func() transport.TPMCloser, auth func(*keyfile.TPMKey) ([]byte, error)) *SSHKeySigner {
+func (k *SSHTPMKey) Signer(keyring *keyring.ThreadKeyring, ownerAuth func() ([]byte, error), tpm func() transport.TPMCloser, auth func(*keyfile.TPMKey) ([]byte, *keyring.Key, error)) *SSHKeySigner {
 	return NewSSHKeySigner(k, keyring, ownerAuth, tpm, auth)
 }
 

--- a/key/signer.go
+++ b/key/signer.go
@@ -17,14 +17,26 @@ import (
 // Shim for keyfile.TPMKeySigner
 // We need access to the SSHTPMKey to change the userauth for caching
 type SSHKeySigner struct {
-	*keyfile.TPMKeySigner
 	key       SSHTPMKeys
 	keyring   *keyring.ThreadKeyring
 	tpm       func() transport.TPMCloser
 	ownerauth func() ([]byte, error)
+
+	// auth returns the userauth bytes along with the locked buffer backing
+	// them if present.
+	auth func(*keyfile.TPMKey) ([]byte, *keyring.Key, error)
 }
 
 var _ crypto.Signer = &SSHKeySigner{}
+
+func (t *SSHKeySigner) Public() crypto.PublicKey {
+	pk, err := t.key.GetTPMKey().PublicKey()
+	// This shouldn't happen!
+	if err != nil {
+		panic(fmt.Errorf("failed producing public: %v", err))
+	}
+	return pk
+}
 
 func (t *SSHKeySigner) Sign(r io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
 	var b []byte
@@ -44,7 +56,7 @@ func (t *SSHKeySigner) Sign(r io.Reader, digest []byte, opts crypto.SignerOpts) 
 		}
 		b, err = key.Sign(t.tpm(), []byte(nil), []byte(nil), digest, digestalg)
 	case *SSHTPMKey:
-		b, err = t.TPMKeySigner.Sign(r, digest, opts)
+		b, err = t.signKey(key, r, digest, opts)
 	default:
 		return nil, fmt.Errorf("this should not happen")
 	}
@@ -56,12 +68,37 @@ func (t *SSHKeySigner) Sign(r io.Reader, digest []byte, opts crypto.SignerOpts) 
 	return b, err
 }
 
-func NewSSHKeySigner(k SSHTPMKeys, keyring *keyring.ThreadKeyring, ownerAuth func() ([]byte, error), tpm func() transport.TPMCloser, auth func(*keyfile.TPMKey) ([]byte, error)) *SSHKeySigner {
+// signKey wraps t.auth to ensure its buffer is wiped and freed before signKey returns.
+func (t *SSHKeySigner) signKey(k *SSHTPMKey, r io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	var boxes []*keyring.Key
+	defer func() {
+		for _, box := range boxes {
+			if err := box.Free(); err != nil {
+				slog.Error("failed to release pin storage", slog.Any("err", err))
+			}
+		}
+	}()
+
+	return keyfile.NewTPMKeySigner(k.TPMKey, t.ownerauth, t.tpm,
+		func(tk *keyfile.TPMKey) ([]byte, error) {
+			key, box, err := t.auth(tk)
+			if box != nil {
+				boxes = append(boxes, box)
+			}
+			if err != nil {
+				return nil, err
+			}
+			return key, nil
+		},
+	).Sign(r, digest, opts)
+}
+
+func NewSSHKeySigner(k SSHTPMKeys, keyring *keyring.ThreadKeyring, ownerAuth func() ([]byte, error), tpm func() transport.TPMCloser, auth func(*keyfile.TPMKey) ([]byte, *keyring.Key, error)) *SSHKeySigner {
 	return &SSHKeySigner{
-		TPMKeySigner: keyfile.NewTPMKeySigner(k.GetTPMKey(), ownerAuth, tpm, auth),
-		keyring:      keyring,
-		tpm:          tpm,
-		ownerauth:    ownerAuth,
-		key:          k,
+		keyring:   keyring,
+		tpm:       tpm,
+		ownerauth: ownerAuth,
+		auth:      auth,
+		key:       k,
 	}
 }


### PR DESCRIPTION
Previously, ssh-tpm-agent would leak the buffer containing the passphrase as the buffer wrapper was dropped.  This is hard to fix as the underlying tpm keyfile library expects a normal go byte slice as the passphrase, not an externally managed memory segment.

This changes the signing module to wrap the passphrase fetching code so the buffer can also be returned, allowing it to be freed when present. It also leaves the option for the askpass machinery to provide similar buffers in the future.